### PR TITLE
Set up page routing 

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard Page</h1>
+    </div>
+  );
+}

--- a/app/events/[id]/edit/page.tsx
+++ b/app/events/[id]/edit/page.tsx
@@ -1,0 +1,7 @@
+export default function EditEvent() {
+  return (
+    <div>
+      <h1>Edit Event Page</h1>
+    </div>
+  );
+}

--- a/app/events/create-event/page.tsx
+++ b/app/events/create-event/page.tsx
@@ -1,0 +1,7 @@
+export default function CreateEvent() {
+  return (
+    <div>
+      <h1>Create Event Page</h1>
+    </div>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,8 @@
+export default function Events() {
+    return (
+      <div>
+        <h1>Events Page</h1>
+      </div>
+    );
+  }
+  

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,7 @@
+export default function ForgotPassword() {
+  return (
+    <div>
+      <h1>Forgot Password Page</h1>
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,7 @@
+export default function Login() {
+  return (
+    <div>
+      <h1>Login Page</h1>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function UserProfile() {
+  return (
+    <div>
+      <h1>User Profile Page</h1>
+    </div>
+  );
+}

--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -1,0 +1,7 @@
+export default function Setting() {
+  return (
+    <div>
+      <h1>Setting Page</h1>
+    </div>
+  );
+}

--- a/app/users/[id]/edit/page.tsx
+++ b/app/users/[id]/edit/page.tsx
@@ -1,0 +1,7 @@
+export default function EditUser() {
+  return (
+    <div>
+      <h1>Edit User Page</h1>
+    </div>
+  );
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,7 @@
+export default function Users() {
+  return (
+    <div>
+      <h1>Users Page</h1>
+    </div>
+  );
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,16 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  async redirects() {
+    return [
+      // Redirect to '/dashboard' by default
+      {
+        source: "/",
+        destination: "/dashboard",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
- Added pages in the `/app` folder (Note: this is latest recommended approach. For more info about the difference, check [here](https://nextjs.org/docs/pages/building-your-application/upgrading/app-router-migration#migrating-from-pages-to-app). 
- Set up route redirecting from '/' to '/dashboard' in `next.config.ts` file. As we show the dashboard by default in our application, we don't actually have a root home page to show. 