### PR TITLE
Fix conflicting page redirect 

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,16 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
-  async redirects() {
-    return [
-      // Redirect to '/dashboard' by default
-      {
-        source: "/",
-        destination: "/dashboard",
-        permanent: true,
-      },
-    ];
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
In the current code, there are two redirect behaviors, one to '/dashboard' and one to '/login' page. I removed the redirect code in `next.config.ts` file. Your browsers might also cache this file, so you can open Network tab and click 'Disable cache' in order to see the change reflected. 