### PR TITLE
Standardize use of @supabase/auth-helper-nextjs

### DIFF
--- a/app/(auth)/set-password/page.tsx
+++ b/app/(auth)/set-password/page.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useEffect, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '@/types/supabase';
+import { createSupabaseClientComponentClient } from '@/lib/supabase/client';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 
 export default function SetPasswordPage() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createSupabaseClientComponentClient();
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -21,93 +20,93 @@ export default function SetPasswordPage() {
   useEffect(() => {
     setError(null);
     setMessage(null);
-    setLoading(true); 
+    setLoading(true);
     setShowPasswordForm(false);
-    
+
     let timerId: NodeJS.Timeout | null = null;
 
     const processHash = async () => {
-        const hash = window.location.hash.substring(1);
-        const params = new URLSearchParams(hash);
-        const accessToken = params.get('access_token');
-        const refreshToken = params.get('refresh_token');
-        const errorDescription = params.get('error_description');
-        const errorCode = params.get('error_code');
+      const hash = window.location.hash.substring(1);
+      const params = new URLSearchParams(hash);
+      const accessToken = params.get('access_token');
+      const refreshToken = params.get('refresh_token');
+      const errorDescription = params.get('error_description');
+      const errorCode = params.get('error_code');
 
-        window.history.replaceState(null, '', window.location.pathname + window.location.search);
+      window.history.replaceState(null, '', window.location.pathname + window.location.search);
 
-        if (errorCode || errorDescription) {
-          const displayError = errorCode === 'otp_expired'
-            ? 'Email link is invalid or has expired. Please request a new one.'
-            : errorDescription || 'Failed to verify link.';
-          setError(displayError);
+      if (errorCode || errorDescription) {
+        const displayError = errorCode === 'otp_expired'
+          ? 'Email link is invalid or has expired. Please request a new one.'
+          : errorDescription || 'Failed to verify link.';
+        setError(displayError);
+        setLoading(false);
+        return;
+      }
+
+      if (accessToken && refreshToken) {
+        const { data, error: sessionError } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+
+        if (sessionError) {
+          setError('Failed to process authentication token after verification.');
           setLoading(false);
-          return; 
-        }
+        } else if (data.session) {
+          const user = data.session.user;
+          const { data: userData, error: dbError } = await supabase
+            .from('users')
+            .select('must_change_password')
+            .eq('id', user.id)
+            .single();
 
-        if (accessToken && refreshToken) {
-          const { data, error: sessionError } = await supabase.auth.setSession({
-            access_token: accessToken,
-            refresh_token: refreshToken,
-          });
-
-          if (sessionError) {
-            setError('Failed to process authentication token after verification.');
-            setLoading(false);
-          } else if (data.session) {
-            const user = data.session.user;
-            const { data: userData, error: dbError } = await supabase
-              .from('users')
-              .select('must_change_password')
-              .eq('id', user.id)
-              .single();
-
-            if (dbError) {
-              setError('Session established, but failed to retrieve user details.');
-              setShowPasswordForm(false);
-            } else if (userData && userData.must_change_password === true) {
-              setShowPasswordForm(true);
-              setError(null);
-              setMessage(null);
-            } else if (userData && userData.must_change_password === false) {
-              setMessage('Password already set. Redirecting...');
-              setShowPasswordForm(false);
-              setTimeout(() => router.push('/dashboard'), 1500); 
-            } else {
-              setError('User account status unclear after login. Contact support.');
-              setShowPasswordForm(false);
-            }
-            if (timerId) clearTimeout(timerId);
-            setLoading(false);
+          if (dbError) {
+            setError('Session established, but failed to retrieve user details.');
+            setShowPasswordForm(false);
+          } else if (userData && userData.must_change_password === true) {
+            setShowPasswordForm(true);
+            setError(null);
+            setMessage(null);
+          } else if (userData && userData.must_change_password === false) {
+            setMessage('Password already set. Redirecting...');
+            setShowPasswordForm(false);
+            setTimeout(() => router.push('/dashboard'), 1500);
           } else {
-            setError('Failed to establish a valid session after verification.');
-            if (timerId) clearTimeout(timerId);
-            setLoading(false);
+            setError('User account status unclear after login. Contact support.');
+            setShowPasswordForm(false);
           }
+          if (timerId) clearTimeout(timerId);
+          setLoading(false);
         } else {
-          const { data: { session } } = await supabase.auth.getSession();
-            if (session) {
-              setMessage('You are already logged in. Redirecting...');
-              setTimeout(() => router.push('/dashboard'), 1500); 
-            } else {
-              setError('Invalid access. Please use the link provided in your email.');
-            }
-            if (timerId) clearTimeout(timerId);
-            setLoading(false);
+          setError('Failed to establish a valid session after verification.');
+          if (timerId) clearTimeout(timerId);
+          setLoading(false);
         }
+      } else {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (session) {
+          setMessage('You are already logged in. Redirecting...');
+          setTimeout(() => router.push('/dashboard'), 1500);
+        } else {
+          setError('Invalid access. Please use the link provided in your email.');
+        }
+        if (timerId) clearTimeout(timerId);
+        setLoading(false);
+      }
     };
 
     processHash();
 
     timerId = setTimeout(() => {
-        if (loading) { 
-            setError("An unexpected error occurred while processing the link. Please try again.");
-            setLoading(false);
-        }
+      if (loading) {
+        setError("An unexpected error occurred while processing the link. Please try again.");
+        setLoading(false);
+      }
     }, 15000);
 
     return () => {
-      if (timerId) clearTimeout(timerId); 
+      if (timerId) clearTimeout(timerId);
     };
 
   }, [supabase, router]);
@@ -125,13 +124,13 @@ export default function SetPasswordPage() {
 
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
-          const { error: dbError } = await supabase
-              .from('users')
-              .update({ must_change_password: false })
-              .eq('id', user.id);
-          if (dbError) {
-              console.warn("Failed to update must_change_password flag after password set:", dbError.message);
-          }
+        const { error: dbError } = await supabase
+          .from('users')
+          .update({ must_change_password: false })
+          .eq('id', user.id);
+        if (dbError) {
+          console.warn("Failed to update must_change_password flag after password set:", dbError.message);
+        }
       }
 
       setMessage("Password successfully set! Redirecting to dashboard...");
@@ -148,12 +147,12 @@ export default function SetPasswordPage() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 bg-gray-100">
-        <div className="mb-8">
-          <Image src="/logo.png" alt="Logo" width={200} height={60} priority />
-        </div>
+      <div className="mb-8">
+        <Image src="/logo.png" alt="Logo" width={200} height={60} priority />
+      </div>
       <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
         <h1 className="text-2xl font-bold text-center text-gray-900">
-            Set Your Password
+          Set Your Password
         </h1>
 
         {loading && <p className="text-center text-gray-600">Verifying invitation...</p>}
@@ -163,23 +162,23 @@ export default function SetPasswordPage() {
         {!loading && !error && message && <p className="text-center text-green-600">{message}</p>}
 
         {!loading && !error && !message && showPasswordForm && (
-             <form onSubmit={handlePasswordSubmit} className="space-y-4">
-                 <div>
-                    <label htmlFor="password">New Password</label>
-                     <Input id="password" name="password" type="password" required minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Enter new password" className="mt-1" disabled={loading} />
-                 </div>
-                 <div>
-                     <label htmlFor="confirmPassword">Confirm Password</label>
-                     <Input id="confirmPassword" name="confirmPassword" type="password" required minLength={8} value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} placeholder="Confirm new password" className="mt-1" disabled={loading} />
-                 </div>
-                 <Button type="submit" className="w-full" disabled={loading}>
-                     {loading ? 'Setting Password...' : 'Set Password and Log In'}
-                 </Button>
-             </form>
+          <form onSubmit={handlePasswordSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="password">New Password</label>
+              <Input id="password" name="password" type="password" required minLength={8} value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Enter new password" className="mt-1" disabled={loading} />
+            </div>
+            <div>
+              <label htmlFor="confirmPassword">Confirm Password</label>
+              <Input id="confirmPassword" name="confirmPassword" type="password" required minLength={8} value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} placeholder="Confirm new password" className="mt-1" disabled={loading} />
+            </div>
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Setting Password...' : 'Set Password and Log In'}
+            </Button>
+          </form>
         )}
 
         {!loading && !error && !message && !showPasswordForm && (
-            <p className="text-center text-gray-600">Please wait or check the link provided in your email.</p>
+          <p className="text-center text-gray-600">Please wait or check the link provided in your email.</p>
         )}
       </div>
     </div>

--- a/app/(main)/events/create-event/page.tsx
+++ b/app/(main)/events/create-event/page.tsx
@@ -5,13 +5,12 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { PageHeader } from "@/components/PageHeader";
 import EventForm, { EventItem } from "@/components/events/EventForm";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import { Database } from "@/types/supabase";
+import { createSupabaseClientComponentClient } from "@/lib/supabase/client";
 import { useUser } from "@/app/context/UserContext";
 
 export default function CreateEventPage() {
   const router = useRouter();
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createSupabaseClientComponentClient();
 
   const { userRole } = useUser();
 
@@ -100,9 +99,9 @@ export default function CreateEventPage() {
           defaultValues={
             userRole === "collaborator"
               ? {
-                  company_id: companyId ?? undefined,
-                  company_name: companyName,
-                }
+                company_id: companyId ?? undefined,
+                company_name: companyName,
+              }
               : {}
           }
           companyName={companyName}

--- a/app/api/companies/route.ts
+++ b/app/api/companies/route.ts
@@ -1,12 +1,10 @@
 // app/api/companies/route.ts
 
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
+import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route";
 import { NextResponse } from "next/server";
-import { Database } from "@/types/supabase";
 
 export async function GET() {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createSupabaseRouteHandlerClient();
 
   const { data, error } = await supabase
     .from("company")

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,10 +1,10 @@
-//api/events/[id]/route.tsf
+//api/events/[id]/route.tsx
 
 import { NextRequest, NextResponse } from "next/server";
-import { createSupabaseServerComponentClient } from "@/lib/supabase/server";
+import { createSupabaseRouteHandlerClient } from "@/lib/supabase/route";
 
 async function getUserAndRole() {
-  const supabase = createSupabaseServerComponentClient();
+  const supabase = createSupabaseRouteHandlerClient();
   const { data: { user }, error: userError } = await supabase.auth.getUser();
   console.log("🔵 User:", user);
   
@@ -30,7 +30,7 @@ async function getUserAndRole() {
 // GET /api/events/:id
 // Fetches a single event by ID
 export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
-    const supabase = createSupabaseServerComponentClient();
+    const supabase = createSupabaseRouteHandlerClient();
     const eventId = Number(params.id);
   
     if (isNaN(eventId)) {
@@ -69,7 +69,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Forbidden" }, { status: 403 }); // ✅ block viewer
   }
 
-  const supabase = createSupabaseServerComponentClient();
+  const supabase = createSupabaseRouteHandlerClient();
   const eventIdRaw = params.id;
   const payload = await req.json();
 
@@ -120,7 +120,7 @@ export async function DELETE(
       return NextResponse.json({ error: "Forbidden" }, { status: 403 }); 
     }
 
-    const supabase = createSupabaseServerComponentClient();
+    const supabase = createSupabaseRouteHandlerClient();
     const eventIdRaw = params.id;
   
     const eventId = Number(eventIdRaw);

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,17 +1,15 @@
 // app/api/events/route.ts
 
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
-import { cookies } from "next/headers";
 import { NextRequest,NextResponse } from 'next/server';
-import { createAdminClient } from '@/lib/supabase/client';
+import { createSupabaseRouteHandlerClient } from '@/lib/supabase/route';
 import { TablesInsert } from "@/types/supabase";
-import { Database } from "@/types/supabase";
 
-const supabase = createAdminClient();
 
 // POST /api/events
 // Creates a new event (admin, collaborator)
 export async function POST(req: NextRequest) {
+  const supabase = createSupabaseRouteHandlerClient();
+
   const body = await req.json();
   console.log("👀 body from server:", body);
 
@@ -57,7 +55,7 @@ export async function POST(req: NextRequest) {
 // Fetches only user's company events (collaborator)
 // Fetches events by company_id (admin, viewer)
 export async function GET(req: NextRequest) {
-  const supabase = createRouteHandlerClient<Database>({ cookies });
+  const supabase = createSupabaseRouteHandlerClient();
 
   const {
     data: { user },

--- a/app/api/imports/route.ts
+++ b/app/api/imports/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createAdminClient } from '@/lib/supabase/client';
+import { createSupabaseRouteHandlerClient } from '@/lib/supabase/route';
 import { ExcelRow } from '@/types/excel';
 
 // ---------- CATEGORY ----------
@@ -53,7 +53,7 @@ const SUBCATEGORY_ENUM_VALUES = [
 
 //---------- Supabase Client ----------
 
-const supabase = createAdminClient();
+const supabase = createSupabaseRouteHandlerClient();
 
 export async function POST(req: NextRequest) {
   const rows: ExcelRow[] = await req.json();

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,7 +1,6 @@
 import { createSupabaseRouteHandlerClient } from '@/lib/supabase/route';
 import { NextRequest, NextResponse } from 'next/server';
 import { authorizeRequest } from '@/lib/api/authUtils';
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import type { Database } from '@/types/supabase';
 
@@ -20,18 +19,16 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const userIdToFetch = params.id;
     const cookieStore = cookies();
-    const supabaseAdmin = createSupabaseRouteHandlerClient();
-    const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
+    const supabase = createSupabaseRouteHandlerClient();
 
     const authResult = await authorizeRequest(request, { 
       allowedRoles: ['admin', 'viewer'], 
       allowSelf: true, 
       targetUserId: userIdToFetch,
-      supabaseClient: supabase 
     });
     if (authResult instanceof NextResponse) return authResult;
 
-    const { data: userData, error: fetchError } = await supabaseAdmin
+    const { data: userData, error: fetchError } = await supabase
       .from('users')
       .select(`
         id, 
@@ -79,16 +76,13 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   const userIdToUpdate = params.id;
-  const supabaseAdmin = createSupabaseRouteHandlerClient(); 
-  const cookieStore = cookies(); 
-  const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore }); 
+  const supabase = createSupabaseRouteHandlerClient(); 
 
   try {
     const authResult = await authorizeRequest(request, { 
       allowedRoles: ['admin'], 
       allowSelf: true,
       targetUserId: userIdToUpdate,
-      supabaseClient: supabase 
     });
     if (authResult instanceof NextResponse) return authResult;
 
@@ -143,7 +137,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       return NextResponse.json({ error: 'No valid fields provided for update' }, { status: 400 });
     }
 
-    const { data: updatedUser, error: updateError } = await supabaseAdmin
+    const { data: updatedUser, error: updateError } = await supabase
       .from('users')
       .update(dataToUpdate)
       .eq('id', userIdToUpdate)
@@ -163,7 +157,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
         return NextResponse.json({ error: 'Password must be at least 6 characters long' }, { status: 400 });
       }
 
-      const { error: passwordError } = await supabaseAdmin.auth.admin.updateUserById(
+      const { error: passwordError } = await supabase.auth.admin.updateUserById(
         userIdToUpdate,
         { password }
       );

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/lib/supabase/client';
+import { createSupabaseRouteHandlerClient } from '@/lib/supabase/route';
 import { NextRequest, NextResponse } from 'next/server';
 import { authorizeRequest } from '@/lib/api/authUtils';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
@@ -20,7 +20,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const userIdToFetch = params.id;
     const cookieStore = cookies();
-    const supabaseAdmin = createAdminClient();
+    const supabaseAdmin = createSupabaseRouteHandlerClient();
     const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
 
     const authResult = await authorizeRequest(request, { 
@@ -79,7 +79,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   const userIdToUpdate = params.id;
-  const supabaseAdmin = createAdminClient(); 
+  const supabaseAdmin = createSupabaseRouteHandlerClient(); 
   const cookieStore = cookies(); 
   const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore }); 
 

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Database } from '@/types/supabase';
-import { createAdminClient } from '@/lib/supabase/client';
+import { createSupabaseRouteHandlerClient } from '@/lib/supabase/route';
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { authorizeRequest } from '@/lib/api/authUtils';
@@ -23,7 +23,7 @@ const inviteUserSchema = z.object({
 export async function GET(request: NextRequest) {
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
-  const supabaseAdmin = createAdminClient();
+  const supabaseAdmin = createSupabaseRouteHandlerClient();
 
   try {
     const authResult = await authorizeRequest(request, { 
@@ -64,7 +64,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const supabaseAdmin = createAdminClient();
+  const supabaseAdmin = createSupabaseRouteHandlerClient();
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
 
@@ -171,7 +171,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const supabaseAdmin = createAdminClient();
+  const supabaseAdmin = createSupabaseRouteHandlerClient();
   const cookieStore = cookies();
   const supabase = createRouteHandlerClient<Database>({ cookies: () => cookieStore });
 

--- a/app/context/UserContext.tsx
+++ b/app/context/UserContext.tsx
@@ -3,8 +3,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
-import type { Database } from "@/types/supabase";
+import { createSupabaseClientComponentClient } from "@/lib/supabase/client";
 
 type UserContextType = {
   userId: string | null;
@@ -19,7 +18,7 @@ const UserContext = createContext<UserContextType>({
 });
 
 export const UserProvider = ({ children }: { children: React.ReactNode }) => {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createSupabaseClientComponentClient();
   const [userId, setUserId] = useState<string | null>(null);
   const [userRole, setUserRole] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/components/dashboard/Dashboard.tsx
+++ b/components/dashboard/Dashboard.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseClientComponentClient } from "@/lib/supabase/client";
 import ExcelUploader from "./ExcelUploader";
 
 export function Dashboard() {
   const [user, setUser] = useState<User | null>(null);
   const [role, setRole] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const supabase = createClientComponentClient();
+  const supabase = createSupabaseClientComponentClient();
 
   useEffect(() => {
     const fetchUser = async () => {

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseClientComponentClient } from "@/lib/supabase/client";
 import { Database } from "@/types/supabase";
 import { useUser } from "@/app/context/UserContext"; // get user info from context
 
@@ -72,7 +72,7 @@ export default function EventForm({
   >([]);
 
   useEffect(() => {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createSupabaseClientComponentClient();
 
     const fetchAllOptions = async () => {
       const [

--- a/components/layouts/DashboardLayout.tsx
+++ b/components/layouts/DashboardLayout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseClientComponentClient } from "@/lib/supabase/client";
 import type { Database } from "@/types/supabase";
 
 import { ReactNode } from "react";
@@ -23,7 +23,7 @@ const defaultNavigation = [
 ];
 
 export function DashboardLayout({ children }: DashboardLayoutProps) {
-  const supabase = createClientComponentClient<Database>();
+  const supabase = createSupabaseClientComponentClient();
 
   const [userId, setUserId] = useState<string | null>(null);
   const [userRole, setUserRole] = useState<string | null>(null);

--- a/lib/supabase/auth.ts
+++ b/lib/supabase/auth.ts
@@ -1,5 +1,4 @@
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
-import { Database } from '@/types/supabase';
+import { createSupabaseClientComponentClient } from './client';
 
 export type UserRole = 'admin' | 'collaborator' | 'viewer';
 
@@ -27,7 +26,7 @@ export interface AuthResponse {
 
 export const checkSession = async (): Promise<AuthResponse> => {
   try {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createSupabaseClientComponentClient();
     const { data: { session }, error } = await supabase.auth.getSession();
 
     if (error || !session) {
@@ -63,7 +62,7 @@ export const checkSession = async (): Promise<AuthResponse> => {
 
 export const signInWithEmail = async (email: string, password: string): Promise<AuthResponse> => {
   try {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createSupabaseClientComponentClient();
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
       password,
@@ -102,7 +101,7 @@ export const signInWithEmail = async (email: string, password: string): Promise<
 
 export const signOut = async (): Promise<{ success: boolean; error?: string }> => {
   try {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createSupabaseClientComponentClient();
     const { error } = await supabase.auth.signOut();
     
     if (error) {
@@ -118,7 +117,7 @@ export const signOut = async (): Promise<{ success: boolean; error?: string }> =
 
 export const getCurrentUser = async (): Promise<AuthResponse> => {
   try {
-    const supabase = createClientComponentClient<Database>();
+    const supabase = createSupabaseClientComponentClient();
     const { data: { user }, error } = await supabase.auth.getUser();
 
     if (error || !user) {

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,56 +1,11 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
 import { Database } from '@/types/supabase';
 
-// Environment variable checks
-if (!process.env.NEXT_PUBLIC_SUPABASE_URL) {
-  throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_URL');
+/**
+ * Creates a Supabase client suitable for Client Components,
+ * using the `@supabase/auth-helpers-nextjs` package.
+ */
+
+export function createSupabaseClientComponentClient() {
+  return createClientComponentClient<Database>();
 }
-
-if (!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-  throw new Error('Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY');
-}
-
-// Browser client (for client-side components)
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  {
-    auth: {
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true
-    }
-  }
-);
-
-// Server client (for public operations)
-export const createServerClient = () => {
-  return createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      auth: {
-        autoRefreshToken: true,
-        persistSession: true
-      }
-    }
-  );
-};
-
-// Admin client (for admin operations)
-export const createAdminClient = () => {
-  if (!process.env.NEXT_PUBLIC_SERVICE_ROLE_KEY) {
-    throw new Error('Missing environment variable: NEXT_PUBLIC_SERVICE_ROLE_KEY');
-  }
-
-  return createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SERVICE_ROLE_KEY,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false
-      }
-    }
-  );
-}; 

--- a/lib/supabase/route.ts
+++ b/lib/supabase/route.ts
@@ -1,0 +1,13 @@
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { Database } from '@/types/supabase';
+import { cookies } from 'next/headers'
+
+/**
+ * Creates a Supabase client suitable for Route Handlers (API routes),
+ * using the `@supabase/auth-helpers-nextjs` package.
+ */
+
+export function createSupabaseRouteHandlerClient() {
+  const cookieStore = cookies()
+  return createRouteHandlerClient<Database>({ cookies: () => cookieStore })
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -6,7 +6,7 @@ import type { Database } from '@/types/supabase';
  * Creates a Supabase client suitable for Server Components,
  * using the `@supabase/auth-helpers-nextjs` package.
  */
-export function createSupabaseServerComponentClient() {
+export async function createSupabaseServerComponentClient() {
   const cookieStore = cookies();
   return createServerComponentClient<Database>({ cookies: () => cookieStore });
 }


### PR DESCRIPTION
This PR resolves: https://github.com/YEONSEO93/hexaTech/issues/124

- [x] Remove usage of `supabase-js` that is not intended for server-side application 
- [x] Refactor existing `client.ts` and `server.ts` in `lib/supabase` to use methods from `@supabase/auth-helper-nextjs` library. Added `route.ts` file to use method from the library intended for route handling such as in  `/api` routes.
- [x] Made any necessary changes to outdated references to functions that have been removed   