### PR TITLE
Hotfix/loading screen

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import "./globals.css";
 import "primeicons/primeicons.css";
 import "../styles/themes/mytheme/theme.scss";
 import { UserProvider } from "./context/UserContext";
+import { LoadingSpinner } from "@/components/loading-spinner";
 
 export default function RootLayout({
   children,
@@ -11,7 +12,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <UserProvider>{children}</UserProvider>
+        <UserProvider>
+          {children}
+          <LoadingSpinner />
+        </UserProvider>
       </body>
     </html>
   );

--- a/components/loading-spinner.tsx
+++ b/components/loading-spinner.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ClipLoader } from "react-spinners";
+import { useEffect, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+export function LoadingSpinner() {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        // Show loading when navigation starts
+        setIsLoading(true);
+
+        // Hide loading after a short delay to ensure content is rendered
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 500);
+
+        return () => clearTimeout(timer);
+    }, [pathname, searchParams]); // This will trigger when the route changes
+
+    // Don't render anything if not loading
+    if (!isLoading) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-white bg-opacity-75">
+            <ClipLoader
+                color="#001F4D"
+                loading={true}
+                size={50}
+                aria-label="Loading Spinner"
+            />
+        </div>
+    );
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -56,15 +56,10 @@ export async function middleware(request: NextRequest) {
 //------------------------------
     // This is a more specific check for the events API
     if (pathname.startsWith('/api/events')) {
-      const { data: userRecord, error: roleError } = await supabase
-        .from("users")
-        .select("role")
-        .eq("id", user.id)
-        .single();
 
-      const userRole = userRecord?.role;
+      const userRole = user?.user_metadata.role;
 
-      if (roleError || !userRole) {
+      if (!userRole) {
         return createErrorResponse("Role not found", 404);
       }
 
@@ -89,16 +84,9 @@ export async function middleware(request: NextRequest) {
       return res;
     }
 
-    // get user role from the database (users table not user_metadata)
-    const { data: userRecord, error: roleError } = await supabase
-      .from("users")
-      .select("role")
-      .eq("id", user.id)
-      .single();
+    const userRole = user?.user_metadata.role;
 
-    const userRole = userRecord?.role;
-
-    if (roleError || !userRole) {
+    if (!userRole) {
       return createErrorResponse("Role not found", 404);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.55.0",
+        "react-spinners": "^0.17.0",
         "recharts": "^2.15.3",
         "tailwind-merge": "^3.1.0",
         "tw-animate-css": "^1.2.5",
@@ -6620,6 +6621,15 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",
+    "react-spinners": "^0.17.0",
     "recharts": "^2.15.3",
     "tailwind-merge": "^3.1.0",
     "tw-animate-css": "^1.2.5",


### PR DESCRIPTION
**Changes in this PR:** 

- [x] Add back the loading spinner solution from @Hyunsoo6257 's original PR: https://github.com/YEONSEO93/hexaTech/pull/130
- [x] Remove unnecessary database queries to check for the user's role in the middleware and instead use `user.user_metadata.role` which is returned from Supabase's `getUser` method. 

**Context:** 

1. Loading Spinner

We have been running into an issue where navigating between pages sometimes freezes for a while before the page loads. 

Screen recording: https://drive.google.com/file/d/1vPJmbjE9u22AdbPGQOIKx2-4JBy142sy/view?usp=drive_link

This is an attempt to fix this by adding a loading spinner to show during the delay. However, this does not entirely solve the problem. After testing, I've found the middleware logic appears to be the reason this freezing/blocking is observed. When removing the middleware layer, the page loads almost instantly. 

However, beyond the initial load, the page load delay decreases significantly and we are able to see the loading spinner in a more timely manner. So, I think it's still a good idea to include it. 

2.  Removing database queries in the middleware 

Before, to check for the user's role, we are making a database query every time in the middleware. The way the middleware logic is set up is that it is run on almost every page, so I believe this database query is unnecessary and costly. It may be related to the `429 Too Many Request` error we recently saw, which appears to be related to Storage service (database) rather than API calls: https://supabase.com/docs/guides/storage/debugging/error-codes#429-too-many-requests

From Supabase's `getUser` method, we have the role information in the `user_metadata` which was set when we created the user. I believe we should switch back to using it to avoid unnecessary database queries that can quickly add up after using the site for a while and when multiple people are using the site. 