### PR TITLE
Hotfix/middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -42,12 +42,9 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   try {
-    //To check if user is logged in, we can use getUser() method directly, as it only returns a user if there is a valid session token. This way, we can also check the role with user.role without a database query
-
-    //Also refer to Supabase Auth docs (Hook up middleware section): https://supabase.com/docs/guides/auth/server-side/nextjs 
-    const { data: { user }, error: userError } = await supabase.auth.getUser();
+    const { data: { session }, error: userError } = await supabase.auth.getSession();
     
-    if (userError || !user) {
+    if (userError || !session?.user) {
       console.error('Authentication error:', userError);
       if (!isPathInRoutes(pathname, ROUTES.AUTH)) {
         return createRedirectResponse(request, '/login');
@@ -55,7 +52,7 @@ export async function middleware(request: NextRequest) {
       return res;
     }
 
-    const userRole = user.user_metadata.role;
+    const userRole = session.user.user_metadata.role;
 
     if (!userRole) {
       return createErrorResponse("Role not found", 404);
@@ -74,7 +71,7 @@ export async function middleware(request: NextRequest) {
     if (pathname.startsWith('/users/')) {
       const pathParts = pathname.split('/');
       const userIdFromPath = pathParts[2];
-      if (userIdFromPath === user.id) {
+      if (userIdFromPath === session.user.id) {
         return res;
       }
     }


### PR DESCRIPTION
This replaces the `getUser` call with `getSession` instead to reduce the likelihood of running into a `429 too many request` error from Supabase from our middleware request. `getSession` only retrieves the session token from the browser cookie, so it's a lot quicker and doesn't hit the Supabase server repeatedly (still not exactly sure the reason for that, but could be when the session token becomes invalid and Supabase tries to refresh the auth token).  

Given our middleware logic to implement role-based access, I think this might be the most viable solution at this point to not introduce any breaking change. 

Fixes: 

- [x] https://github.com/YEONSEO93/hexaTech/issues/140#issue-3076925987
